### PR TITLE
Fix tide parent dirs variables scope

### DIFF
--- a/functions/_tide_parent_dirs.fish
+++ b/functions/_tide_parent_dirs.fish
@@ -1,7 +1,7 @@
 function _tide_parent_dirs --on-variable PWD
     set -g _tide_parent_dirs (string escape (
         for dir in (string split / -- $PWD)
-            set -la parts $dir
+            set -fa parts $dir
             string join / -- $parts
         end))
 end


### PR DESCRIPTION
It looks like in fish-3 the local variable parts was being treated as
a function scoped variable. In fish-4 this appears to be corrected and
the variable scope is now in the for loop.