### PR TITLE
Add gh cli user item

### DIFF
--- a/functions/_tide_item_gh_user.fish
+++ b/functions/_tide_item_gh_user.fish
@@ -1,0 +1,17 @@
+function _tide_item_gh_user
+    # Default icon
+    set -q tide_gh_user_icon; or set -l tide_gh_user_icon ''
+
+    # Default config path
+    set -l gh_hosts_file ~/.config/gh/hosts.yml
+    set -l user
+
+    if test -f $gh_hosts_file
+        # Find the first 'user:' line after a host (e.g. github.com:)
+        set user (cat $gh_hosts_file | string match -rg '^[ ]*user:[ ]*(.+)$')
+    end
+
+    if test -n "$user"
+        _tide_print_item gh_user $tide_gh_user_icon' '$user
+    end
+end

--- a/functions/tide/configure/configs/classic.fish
+++ b/functions/tide/configure/configs/classic.fish
@@ -118,3 +118,6 @@ tide_vi_mode_color_replace 87AF87
 tide_vi_mode_color_visual FF8700
 tide_zig_bg_color 444444
 tide_zig_color F7A41D
+
+tide_gh_user_bg_color normal
+tide_gh_user_color 0087AF

--- a/functions/tide/configure/configs/classic_16color.fish
+++ b/functions/tide/configure/configs/classic_16color.fish
@@ -91,3 +91,5 @@ tide_vi_mode_color_replace green
 tide_vi_mode_color_visual yellow
 tide_zig_bg_color black
 tide_zig_color yellow
+tide_gh_user_bg_color black
+tide_gh_user_color cyan

--- a/functions/tide/configure/configs/lean.fish
+++ b/functions/tide/configure/configs/lean.fish
@@ -118,3 +118,6 @@ tide_vi_mode_color_replace 87AF87
 tide_vi_mode_color_visual FF8700
 tide_zig_bg_color normal
 tide_zig_color F7A41D
+
+tide_gh_user_bg_color 444444
+tide_gh_user_color 5FAFFF

--- a/functions/tide/configure/configs/lean_16color.fish
+++ b/functions/tide/configure/configs/lean_16color.fish
@@ -91,3 +91,5 @@ tide_vi_mode_color_replace green
 tide_vi_mode_color_visual yellow
 tide_zig_bg_color normal
 tide_zig_color yellow
+tide_gh_user_bg_color normal
+tide_gh_user_color cyan

--- a/functions/tide/configure/configs/rainbow.fish
+++ b/functions/tide/configure/configs/rainbow.fish
@@ -118,3 +118,6 @@ tide_vi_mode_color_replace 000000
 tide_vi_mode_color_visual 000000
 tide_zig_bg_color F7A41D
 tide_zig_color 000000
+
+tide_gh_user_bg_color 444444
+tide_gh_user_color 5FAFFF

--- a/functions/tide/configure/configs/rainbow_16color.fish
+++ b/functions/tide/configure/configs/rainbow_16color.fish
@@ -95,3 +95,5 @@ tide_vi_mode_icon_replace R
 tide_vi_mode_icon_visual V
 tide_zig_bg_color yellow
 tide_zig_color black
+tide_gh_user_bg_color blue
+tide_gh_user_color brwhite

--- a/tests/_tide_item_gh_user.test.fish
+++ b/tests/_tide_item_gh_user.test.fish
@@ -1,0 +1,39 @@
+# Test for _tide_item_gh_user
+
+set -l test_hosts_file (mktemp)
+set -l gh_hosts_file $HOME/.config/gh/hosts.yml
+set -l backup_hosts_file
+
+# Backup existing hosts.yml if it exists
+if test -f $gh_hosts_file
+    set backup_hosts_file (mktemp)
+    cp $gh_hosts_file $backup_hosts_file
+end
+
+# Prepare a mock hosts.yml
+mkdir -p ~/.config/gh
+printf 'github.com:\n    git_protocol: https\n    users:\n        testuser:\n    user: testuser\n' > $test_hosts_file
+cp $test_hosts_file $gh_hosts_file
+
+# Set icon and color for test
+set -g tide_gh_user_icon 'ï'
+set -g tide_gh_user_color 0087AF
+set -g tide_gh_user_bg_color normal
+
+# Capture output
+set -g _tide_side right
+set -l output (_tide_item_gh_user)
+
+# Clean up test files
+rm $test_hosts_file
+
+# Restore original hosts.yml or remove test file
+if test -n "$backup_hosts_file"
+    cp $backup_hosts_file $gh_hosts_file
+    rm $backup_hosts_file
+else
+    rm $gh_hosts_file
+end
+
+# Assert output contains icon and username
+string match -q '*ï testuser*' -- $output


### PR DESCRIPTION
#### Description

This adds support for showing the actively logged on github cli user name.

#### Motivation and Context

For people who use multiple GitHub accounts, it helps to know which one is active before using the GitHub CLI:

- Trying to SSH into a work Codespace vs personal Codespace
- Trying to push to a personal repo vs work repo (failing since the active account mismatches)
- etc.

#### Screenshots (if appropriate)

<img width="139" height="37" alt="image" src="https://github.com/user-attachments/assets/d8f75df8-78e3-4212-b428-3b0e9c5236f3" />